### PR TITLE
Add rbenv directory format

### DIFF
--- a/lib/byebug/skipper.rb
+++ b/lib/byebug/skipper.rb
@@ -7,6 +7,7 @@ module Byebug::Skipper
     %r{/ruby/[^/]+(/bundler)?/gems/}, # gems installed globally or via Bundler
     %r{/ruby-[^/]+/gems/}, # RVM directory format
     %r{/ruby-[^/]+/lib/ruby/[^/]+/}, # Ruby built-in files
+    %r{/versions/[^/]+/lib/ruby/gems/}, # RBEnv directory format
   ].freeze
 
   def skip_matchers

--- a/spec/byebug-skipper_spec.rb
+++ b/spec/byebug-skipper_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Byebug::Skipper do
       .to be(true)
     expect(subject.skip?('/Users/blakeastley/.rvm/gems/ruby-2.7.3/gems/active_interaction-4.0.1/lib/active_interaction/concerns/runnable.rb'))
       .to be(true)
+    expect(subject.skip?('/Users/hoylemd/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.1.7.3/lib/active_support/json/decoding.rb:23'))
+      .to be(true)
   end
 
   it 'skips Ruby built-in paths by default' do


### PR DESCRIPTION
[RBenv](https://github.com/rbenv/rbenv) is the ruby version manager that I use, and I'm probably not the only one. So I added a matcher for the install directory pattern that it uses.

Tested by setting up my bundler for another project to point at my local repo and triggered a byebug session. Checked that `ups` works as expected. Also ran rspec tests, and added one more case for an rbenv style path.

I used the pattern here to be just inside the rbenv install directory (which is `HOME/.rbenv` by default, but can be changed), so the actual location of it isn't important, only the top-level structure, so that it 'just works' no matter one's rbenv config.